### PR TITLE
Fix null pointer dereference - issue 6

### DIFF
--- a/compat.c
+++ b/compat.c
@@ -439,6 +439,9 @@ int id3_compat_fixup(struct id3_tag *tag)
     encoding = id3_parse_uint(&data, 1);
     string   = id3_parse_string(&data, end - data, encoding, 0);
 
+	if (!string)
+		continue;
+
     if (id3_ucs4_length(string) < 4) {
       free(string);
       continue;

--- a/ucs4.c
+++ b/ucs4.c
@@ -37,6 +37,9 @@ id3_ucs4_t const id3_ucs4_empty[] = { 0 };
  */
 id3_length_t id3_ucs4_length(id3_ucs4_t const *ucs4)
 {
+	if (!ucs4)
+		return 0;
+
   id3_ucs4_t const *ptr = ucs4;
 
   while (*ptr)


### PR DESCRIPTION
See issue #6 

Not sure if this will cause further issues, but at least it seems to stop `mpd` from segfaulting